### PR TITLE
Fix: Update pydantic to version 2.8.2 for Python 3.13 compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
-pydantic==2.5.0
+pydantic~=2.8.2
 python-multipart==0.0.6


### PR DESCRIPTION
This change updates pydantic from 2.5.0 to ~2.8.2 to resolve a build issue encountered on Cloudflare Workers with Python 3.13.3. The error was related to `pydantic-core`'s build script and its interaction with `ForwardRef` in Python 3.13.

Pydantic 2.8.x versions provide official support for Python 3.13, which should address this incompatibility.